### PR TITLE
fix: Adapt esbuild wildcard rule & fix Windows path handling

### DIFF
--- a/src/file-utils.test.ts
+++ b/src/file-utils.test.ts
@@ -33,4 +33,9 @@ describe("sanitizePath", () => {
 	it("should replace dots with underscores", () => {
 		expect(sanitizePath("foo.bar.js")).toBe("foo_bar_js");
 	});
+
+	// windows path
+	it("should replace colons with underscores", () => {
+		expect(sanitizePath("C:/src/foo.js")).toBe("C__src_foo_js");
+	});
 });

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -5,5 +5,5 @@ export function generateFileId(filePath: string): string {
 }
 
 export function sanitizePath(filePath: string): string {
-	return filePath.replace(/^\//, "").replace(/[/.]/g, "_");
+	return filePath.replace(/^\//, "").replace(/[/.]/g, "_").replace(/:/g, "_");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export default function golangPlugin(
 		config() {
 			return {
 				optimizeDeps: {
-					exclude: ["/@vite-golang/**"],
+					exclude: ["/@vite-golang/*"],
 					esbuildOptions: {
 						plugins: [
 							{


### PR DESCRIPTION
1. update `optimizeDeps.exclude` from `/@vite-golang/**` to `/@vite-golang/*` to comply with esbuild's single `*` wildcard restriction (ref: https://github.com/evanw/esbuild/blob/9129e00e6c36a3e374820cb5e3fc2cd319c8ab85/pkg/api/api_impl.go#L436)
2. fix `sanitizePath` not handling colons in Windows paths, add colon replacement logic and corresponding unit test
3. resolves: #2

### Error Screenshots
<img width="1642" height="427" src="https://github.com/user-attachments/assets/ea58cbd3-38f4-4d0f-9927-1e020edc645e" />
